### PR TITLE
Support noble only

### DIFF
--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,6 +1,0 @@
-gz-msgs12 (11.999.999-1~jammy) jammy; urgency=medium
-
-  * Stub to be removed after first entry
-
- -- Carlos Aguero <caguero@openrobotics.org>  Tue, 08 Oct 2024 20:56:01 +0200
-

--- a/jammy/debian/compat
+++ b/jammy/debian/compat
@@ -1,1 +1,0 @@
-../../ubuntu/debian/compat

--- a/jammy/debian/control
+++ b/jammy/debian/control
@@ -1,1 +1,0 @@
-../../ubuntu/debian/control

--- a/jammy/debian/copyright
+++ b/jammy/debian/copyright
@@ -1,1 +1,0 @@
-../../ubuntu/debian/copyright

--- a/jammy/debian/gz-msgs12-cli.install
+++ b/jammy/debian/gz-msgs12-cli.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/gz-msgs-cli.install

--- a/jammy/debian/libgz-msgs12-dev.install
+++ b/jammy/debian/libgz-msgs12-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-msgs-dev.install

--- a/jammy/debian/libgz-msgs12.install
+++ b/jammy/debian/libgz-msgs12.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-msgs.install

--- a/jammy/debian/python3-gz-msgs12.install
+++ b/jammy/debian/python3-gz-msgs12.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/python3-gz-msgs.install

--- a/jammy/debian/rules
+++ b/jammy/debian/rules
@@ -1,1 +1,0 @@
-../../ubuntu/debian/rules

--- a/jammy/debian/source
+++ b/jammy/debian/source
@@ -1,1 +1,0 @@
-../../ubuntu/debian/source


### PR DESCRIPTION
The next Gazebo distribution will support only noble and newer versions of Ubuntu. This PR adds noble and removes older distributions.