### PR TITLE
Add new libgz jetty aliases

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -111,3 +111,20 @@ Priority: optional
 Section: metapackages
 Description: alias package
  Provides a package for Jetty without exposing the version number.
+
+Package: libgz-jetty-msgs-dev
+Depends: libgz-msgs12-dev (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.
+
+Package: python3-gz-jetty-msgs
+Depends: python3-gz-msgs12 (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.
+


### PR DESCRIPTION
Added the same kind of aliases than the ones used for rotary. See
https://github.com/gazebo-tooling/release-tools/issues/1446